### PR TITLE
Add position 2D as parameter

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -18,6 +18,8 @@ pub struct LayerData {
     pub scale: f32,
     /// Z position of the layer
     pub z: f32,
+    /// Default initial position of the Entity container
+    pub position: Vec2,
     /// Number used to determine when textures are moved to opposite side of camera
     pub transition_factor: f32,
 }
@@ -32,6 +34,7 @@ impl Default for LayerData {
             rows: 1,
             scale: 1.0,
             z: 0.0,
+            position: Vec2::ZERO,
             transition_factor: 1.2,
         }
     }

--- a/src/parallax.rs
+++ b/src/parallax.rs
@@ -79,7 +79,7 @@ impl ParallaxResource {
             entity_commands
                 .insert(Name::new(format!("Parallax Layer ({})", i)))
                 .insert(Transform {
-                    translation: Vec3::new(0.0, 0.0, layer.z),
+                    translation: Vec3::new(layer.position.x, layer.position.y, layer.z),
                     scale: Vec3::new(layer.scale, layer.scale, 1.0),
                     ..Default::default()
                 })


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature

## Did this PR introduce a breaking change?
No

## More details
This is because in my case and most probably many others, it was not possible to modify the initial position of the sprites, in this case I added a position parameter in Vector2 in case someone decides to keep the position at zero except for the depth (z), so I left them as two separate parameters, also this way it does not affect those who already used the library