### PR TITLE
Update to Bevy 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,25 @@ keywords = ["bevy", "gamedev", "parallax", "scrolling", "background"]
 exclude = ["assets/*"]
 
 [dependencies]
-bevy = "0.7.0"
 serde = "1.0.136"
 
+[dependencies.bevy]
+version = "0.8.0"
+default-features = false
+features = [
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_sprite",
+    "bevy_asset",
+    "bevy_winit",
+]
+
 [dev-dependencies]
-bevy-inspector-egui = "0.10.0"
+# Temporarily removed until it updates to Bevy 0.8
+# bevy-inspector-egui = "0.11.0"
 ron = "0.7.0"
+
+[dev-dependencies.bevy]
+version = "0.8.0"
+default-features = false
+features = ["x11", "png"]

--- a/examples/cyberpunk.rs
+++ b/examples/cyberpunk.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy::{prelude::*, render::texture::ImageSettings};
 use bevy_parallax::{
     LayerData, ParallaxCameraComponent, ParallaxMoveEvent, ParallaxPlugin, ParallaxResource,
 };
@@ -16,6 +15,8 @@ fn main() {
 
     App::new()
         .insert_resource(window)
+        // Use nearest filtering so our pixel art renders clear
+        .insert_resource(ImageSettings::default_nearest())
         // Add parallax resource with layer data
         .insert_resource(ParallaxResource {
             layer_data: vec![
@@ -53,7 +54,6 @@ fn main() {
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
-        .add_plugin(WorldInspectorPlugin::new())
         .add_plugin(ParallaxPlugin)
         .add_startup_system(initialize_camera_system)
         .add_system(move_camera_system)
@@ -63,7 +63,7 @@ fn main() {
 // Put a ParallaxCameraComponent on the camera used for parallax
 pub fn initialize_camera_system(mut commands: Commands) {
     commands
-        .spawn_bundle(OrthographicCameraBundle::new_2d())
+        .spawn_bundle(Camera2dBundle::default())
         .insert(ParallaxCameraComponent);
 }
 

--- a/examples/fishy.rs
+++ b/examples/fishy.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy::{prelude::*, render::texture::ImageSettings};
 use bevy_parallax::{
     LayerData, ParallaxCameraComponent, ParallaxMoveEvent, ParallaxPlugin, ParallaxResource,
 };
@@ -17,6 +16,8 @@ fn main() {
 
     App::new()
         .insert_resource(window)
+        // Use nearest filtering so our pixel art renders clear
+        .insert_resource(ImageSettings::default_nearest())
         // Add parallax resource with layer data (from ron file)
         .insert_resource(ParallaxResource {
             layer_data: from_bytes::<Vec<LayerData>>(include_bytes!(
@@ -26,7 +27,6 @@ fn main() {
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
-        .add_plugin(WorldInspectorPlugin::new())
         .add_plugin(ParallaxPlugin)
         .add_startup_system(initialize_camera_system)
         .add_system(move_camera_system)
@@ -36,7 +36,7 @@ fn main() {
 // Put a ParallaxCameraComponent on the camera used for parallax
 pub fn initialize_camera_system(mut commands: Commands) {
     commands
-        .spawn_bundle(OrthographicCameraBundle::new_2d())
+        .spawn_bundle(Camera2dBundle::default())
         .insert(ParallaxCameraComponent);
 }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 /// Layer initialization data
 #[derive(Debug, Deserialize)]
+#[serde(default)]
 pub struct LayerData {
     /// Relative speed of layer to the camera movement
     pub speed: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ fn update_layer_textures_system(
                 let (texture_gtransform, mut texture_transform, layer_texture) =
                     texture_query.get_mut(child).unwrap();
 
+                let texture_gtransform = texture_gtransform.compute_transform();
+
                 // Move right-most texture to left side of layer when camera is approaching left-most end
                 if camera_transform.translation.x - texture_gtransform.translation.x
                     + ((layer_texture.width * texture_gtransform.scale.x) / 2.0)

--- a/src/parallax.rs
+++ b/src/parallax.rs
@@ -78,12 +78,14 @@ impl ParallaxResource {
             let mut entity_commands = commands.spawn();
             entity_commands
                 .insert(Name::new(format!("Parallax Layer ({})", i)))
-                .insert(Transform {
-                    translation: Vec3::new(layer.position.x, layer.position.y, layer.z),
-                    scale: Vec3::new(layer.scale, layer.scale, 1.0),
-                    ..Default::default()
+                .insert_bundle(SpatialBundle {
+                    transform: Transform {
+                        translation: Vec3::new(layer.position.x, layer.position.y, layer.z),
+                        scale: Vec3::new(layer.scale, layer.scale, 1.0),
+                        ..default()
+                    },
+                    ..default()
                 })
-                .insert(GlobalTransform::default())
                 .with_children(|parent| {
                     // Spawn center texture
                     parent.spawn_bundle(spritesheet_bundle.clone()).insert(


### PR DESCRIPTION
- Make sure that we only depend on Bevy features we need
- Temporarily disable Bevy Egui World inspector until it updates to
Bevy 0.8.
- Add Serde default to LayerData so that the RON demo deserializes
correctly without needing to specify default options.