### PR TITLE
Fix crate release mode Bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ features = [
     "bevy_sprite",
     "bevy_asset",
     "bevy_winit",
+    "x11",
+    "png",
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
The release mode was missing some Bevy features that the the dev mode had.