### PR TITLE
Fix Docs.rs Build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ ron = "0.7.0"
 version = "0.8.0"
 default-features = false
 features = ["x11", "png"]
+
+[package.metadata.docs.rs]
+features = ["bevy/x11"]


### PR DESCRIPTION
Adds the `bevy/x11` feature to the docs.rs build config.