### PR TITLE
update crate and examples to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["bevy", "gamedev", "parallax", "scrolling", "background"]
 exclude = ["assets/*"]
 
 [dependencies]
-serde = "1.0.136"
+serde = "1.0.180"
 
 [dependencies.bevy]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 features = [
     "bevy_render",
@@ -31,7 +31,7 @@ features = [
 ron = "0.8.0"
 
 [dev-dependencies.bevy]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 features = ["x11", "png"]
 

--- a/examples/cyberpunk.rs
+++ b/examples/cyberpunk.rs
@@ -23,9 +23,9 @@ fn main() {
                 // Use nearest filtering so our pixel art renders clear
                 .set(ImagePlugin::default_nearest()),
         )
-        .add_plugin(ParallaxPlugin)
-        .add_startup_system(initialize_camera_system)
-        .add_system(move_camera_system.before(ParallaxSystems))
+        .add_plugins(ParallaxPlugin)
+        .add_systems(Startup, initialize_camera_system)
+        .add_systems(Update, move_camera_system.before(ParallaxSystems))
         .run();
 }
 

--- a/examples/fishy.rs
+++ b/examples/fishy.rs
@@ -24,9 +24,9 @@ fn main() {
                 // Use nearest filtering so our pixel art renders clear
                 .set(ImagePlugin::default_nearest()),
         )
-        .add_plugin(ParallaxPlugin)
-        .add_startup_system(initialize_camera_system)
-        .add_system(move_camera_system.before(ParallaxSystems))
+        .add_plugins(ParallaxPlugin)
+        .add_systems(Startup, initialize_camera_system)
+        .add_systems(Update, move_camera_system.before(ParallaxSystems))
         .run();
 }
 

--- a/examples/sky.rs
+++ b/examples/sky.rs
@@ -23,9 +23,9 @@ fn main() {
                 // Use nearest filtering so our pixel art renders clear
                 .set(ImagePlugin::default_nearest()),
         )
-        .add_plugin(ParallaxPlugin)
-        .add_startup_system(initialize_camera_system)
-        .add_system(move_camera_system.before(ParallaxSystems))
+        .add_plugins(ParallaxPlugin)
+        .add_systems(Startup, initialize_camera_system)
+        .add_systems(Update, move_camera_system.before(ParallaxSystems))
         .run();
 }
 

--- a/examples/split.rs
+++ b/examples/split.rs
@@ -27,9 +27,9 @@ fn main() {
                 // Use nearest filtering so our pixel art renders clear
                 .set(ImagePlugin::default_nearest()),
         )
-        .add_plugin(ParallaxPlugin)
-        .add_startup_system(initialize_camera_system)
-        .add_system(move_camera_system.before(ParallaxSystems))
+        .add_plugins(ParallaxPlugin)
+        .add_systems(Startup, initialize_camera_system)
+        .add_systems(Update, move_camera_system.before(ParallaxSystems))
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,12 @@ impl Plugin for ParallaxPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<ParallaxMoveEvent>()
             .add_event::<CreateParallaxEvent>()
-            .add_systems((create_parallax_system, follow_camera_system).in_set(ParallaxSystems))
-            .add_system(
+            .add_systems(
+                Update,
+                (create_parallax_system, follow_camera_system).in_set(ParallaxSystems),
+            )
+            .add_systems(
+                Update,
                 update_layer_textures_system
                     .in_set(ParallaxSystems)
                     .after(follow_camera_system),

--- a/src/parallax.rs
+++ b/src/parallax.rs
@@ -4,7 +4,7 @@ use crate::layer;
 use bevy::{prelude::*, render::view::RenderLayers};
 
 /// Event to setup and create parallax
-#[derive(Debug)]
+#[derive(Event, Debug)]
 pub struct CreateParallaxEvent {
     pub layers_data: Vec<layer::LayerData>,
     pub camera: Entity,
@@ -121,6 +121,7 @@ impl CreateParallaxEvent {
 }
 
 /// Event used to update parallax
+#[derive(Event)]
 pub struct ParallaxMoveEvent {
     /// Speed to move camera
     pub camera_move_speed: Vec2,


### PR DESCRIPTION
Small change log, tested all the examples and they work as expected. All that was needed was `#[derive(Event)]` and updates to schedule first add_systems API.