### PR TITLE
Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+name: Publish
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ features = [
     "bevy_core_pipeline",
     "bevy_sprite",
     "bevy_asset",
-    "bevy_winit",
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-parallax"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Carlo Supina <cdsupina@gmail.com>"]
 edition = "2021"
 description = "A Bevy plugin for creating a parallax effect."


### PR DESCRIPTION
This will publish the crate every time that a tag is pushed to the repo
It is necessary to set the secret CARGO_REGISTRY_TOKEN

Related to: https://github.com/Corrosive-Games/bevy-parallax/issues/29