### PR TITLE
add repeat option to layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ features = [
 ]
 
 [dev-dependencies]
-# Temporarily removed until it updates to Bevy 0.8
-# bevy-inspector-egui = "0.11.0"
+bevy-inspector-egui = "0.19.0"
 ron = "0.8.0"
 
 [dev-dependencies.bevy]

--- a/data/fishy_layer_data.ron
+++ b/data/fishy_layer_data.ron
@@ -7,7 +7,6 @@
 		rows: 1,
 		scale: 1.25,
 		z: 0.0,
-		transition_factor: 1.2,
 		color: Rgba(
 			red: 0.5,
 	        green: 0.8,
@@ -23,7 +22,6 @@
 		rows: 1,
 		scale: 1.25,
 		z: 1.0,
-		transition_factor: 1.2,
 		color: Rgba(
 			red: 0.5,
 	        green: 0.8,
@@ -39,7 +37,6 @@
 		rows: 1,
 		scale: 1.25,
 		z: 2.0,
-		transition_factor: 1.2,
 		color: Rgba(
 			red: 0.7,
 	        green: 0.6,
@@ -55,7 +52,6 @@
 		rows: 1,
 		scale: 1.25,
 		z: 3.0,
-		transition_factor: 1.2,
 		color: Rgba(
 			red: 0.7,
 	        green: 0.6,
@@ -71,7 +67,6 @@
 		rows: 1,
 		scale: 1.25,
 		z: 4.0,
-		transition_factor: 1.2,
 		color: Rgba(
 			red: 0.7,
 	        green: 0.6,
@@ -87,7 +82,6 @@
 		rows: 1,
 		scale: 1.25,
 		z: 5.0,
-		transition_factor: 1.2,
 		color: Rgba(
 			red: 0.7,
 	        green: 0.6,

--- a/examples/cyberpunk.rs
+++ b/examples/cyberpunk.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_parallax::{
     CreateParallaxEvent, LayerData, LayerRepeat, LayerSpeed, ParallaxCameraComponent,
     ParallaxMoveEvent, ParallaxPlugin, ParallaxSystems, RepeatStrategy,
@@ -24,6 +25,7 @@ fn main() {
                 .set(ImagePlugin::default_nearest()),
         )
         .add_plugins(ParallaxPlugin)
+        .add_plugins(WorldInspectorPlugin::new())
         .add_systems(Startup, initialize_camera_system)
         .add_systems(Update, move_camera_system.before(ParallaxSystems))
         .insert_resource(ClearColor(Color::rgb_u8(42, 0, 63)))
@@ -43,17 +45,17 @@ pub fn initialize_camera_system(
         layers_data: vec![
             LayerData {
                 speed: LayerSpeed::Bidirectional(0.9, 0.9),
-                repeat: LayerRepeat::horizontally(RepeatStrategy::Mirror),
+                repeat: LayerRepeat::horizontally(RepeatStrategy::Same),
                 path: "cyberpunk_back.png".to_string(),
                 tile_size: Vec2::new(96.0, 160.0),
                 cols: 1,
                 rows: 1,
                 scale: 4.5,
                 z: 0.0,
-                ..Default::default()
+                ..default()
             },
             LayerData {
-                speed: LayerSpeed::Bidirectional(0.6, 0.6),
+                speed: LayerSpeed::Bidirectional(0.6, 0.8),
                 repeat: LayerRepeat::horizontally(RepeatStrategy::Same),
                 path: "cyberpunk_middle.png".to_string(),
                 tile_size: Vec2::new(144.0, 160.0),
@@ -61,18 +63,18 @@ pub fn initialize_camera_system(
                 rows: 1,
                 scale: 4.5,
                 z: 1.0,
-                ..Default::default()
+                ..default()
             },
             LayerData {
-                speed: LayerSpeed::Bidirectional(0.1, 0.1),
-                repeat: LayerRepeat::horizontally(RepeatStrategy::Mirror),
+                speed: LayerSpeed::Bidirectional(0.1, 0.3),
+                repeat: LayerRepeat::both(RepeatStrategy::Mirror),
                 path: "cyberpunk_front.png".to_string(),
                 tile_size: Vec2::new(272.0, 160.0),
                 cols: 1,
                 rows: 1,
                 scale: 4.5,
                 z: 2.0,
-                ..Default::default()
+                ..default()
             },
         ],
         camera: camera,
@@ -83,24 +85,31 @@ pub fn initialize_camera_system(
 pub fn move_camera_system(
     keyboard_input: Res<Input<KeyCode>>,
     mut move_event_writer: EventWriter<ParallaxMoveEvent>,
-    camera_query: Query<Entity, With<Camera>>,
+    mut camera_query: Query<(Entity, &mut Transform), With<Camera>>,
 ) {
-    let camera = camera_query.get_single().unwrap();
-    let mut speed = Vec2::ZERO;
+    let (camera, mut camera_transform) = camera_query.get_single_mut().unwrap();
+    let speed = 9.;
+    let mut direction = Vec2::ZERO;
     if keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right) {
-        speed += Vec2::new(3.0, 0.0);
+        direction += Vec2::new(1.0, 0.0);
     }
     if keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left) {
-        speed += Vec2::new(-3.0, 0.0);
+        direction += Vec2::new(-1.0, 0.0);
     }
     if keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up) {
-        speed += Vec2::new(0.0, 3.0);
+        direction += Vec2::new(0.0, 1.0);
     }
     if keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down) {
-        speed += Vec2::new(0.0, -3.0);
+        direction += Vec2::new(0.0, -1.0);
+    }
+    if keyboard_input.pressed(KeyCode::E) {
+        camera_transform.rotate_z(0.1);
+    }
+    if keyboard_input.pressed(KeyCode::Q) {
+        camera_transform.rotate_z(-0.1);
     }
     move_event_writer.send(ParallaxMoveEvent {
-        camera_move_speed: speed,
+        camera_move_speed: direction.normalize_or_zero() * speed,
         camera: camera,
     });
 }

--- a/examples/split.rs
+++ b/examples/split.rs
@@ -4,8 +4,8 @@ use bevy::{
     render::{camera::Viewport, view::RenderLayers},
 };
 use bevy_parallax::{
-    CreateParallaxEvent, LayerData, LayerSpeed, ParallaxCameraComponent, ParallaxMoveEvent,
-    ParallaxPlugin, ParallaxSystems,
+    CreateParallaxEvent, LayerData, LayerSpeed, LayerRepeat, ParallaxCameraComponent, ParallaxMoveEvent,
+    ParallaxPlugin, ParallaxSystems, RepeatStrategy,
 };
 
 fn main() {
@@ -82,6 +82,7 @@ pub fn initialize_camera_system(
         layers_data: vec![
             LayerData {
                 speed: LayerSpeed::Horizontal(0.9),
+                repeat: LayerRepeat::horizontally(RepeatStrategy::Same),
                 path: "cyberpunk_back.png".to_string(),
                 tile_size: Vec2::new(96.0, 160.0),
                 cols: 1,
@@ -92,6 +93,7 @@ pub fn initialize_camera_system(
             },
             LayerData {
                 speed: LayerSpeed::Horizontal(0.6),
+                repeat: LayerRepeat::horizontally(RepeatStrategy::Same),
                 path: "cyberpunk_middle.png".to_string(),
                 tile_size: Vec2::new(144.0, 160.0),
                 cols: 1,
@@ -102,6 +104,7 @@ pub fn initialize_camera_system(
             },
             LayerData {
                 speed: LayerSpeed::Horizontal(0.1),
+                repeat: LayerRepeat::horizontally(RepeatStrategy::Same),
                 path: "cyberpunk_front.png".to_string(),
                 tile_size: Vec2::new(272.0, 160.0),
                 cols: 1,

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -11,6 +11,81 @@ pub enum LayerSpeed {
     Bidirectional(f32, f32),
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub enum RepeatStrategy {
+    Same,
+    Mirror,
+}
+
+impl RepeatStrategy {
+    pub fn transform(
+        &self,
+        mut spritesheet_bundle: SpriteSheetBundle,
+        pos: (i32, i32),
+    ) -> SpriteSheetBundle {
+        match self {
+            Self::Same => spritesheet_bundle,
+            Self::Mirror => {
+                let (x, y) = pos;
+                spritesheet_bundle.sprite.flip_x = x % 2 != 0;
+                spritesheet_bundle.sprite.flip_y = y % 2 != 0;
+                spritesheet_bundle
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub enum LayerRepeat {
+    Horizontal(RepeatStrategy),
+    Vertical(RepeatStrategy),
+    Bidirectional(RepeatStrategy, RepeatStrategy),
+}
+
+impl LayerRepeat {
+    pub fn both(strategy: RepeatStrategy) -> Self {
+        Self::Bidirectional(strategy.clone(), strategy)
+    }
+
+    pub fn horizontally(strategy: RepeatStrategy) -> Self {
+        Self::Horizontal(strategy)
+    }
+
+    pub fn vertically(strategy: RepeatStrategy) -> Self {
+        Self::Vertical(strategy)
+    }
+
+    pub fn has_vertical(&self) -> bool {
+        match self {
+            Self::Horizontal(_) => false,
+            _ => true,
+        }
+    }
+
+    pub fn has_horizontal(&self) -> bool {
+        match self {
+            Self::Vertical(_) => false,
+            _ => true,
+        }
+    }
+
+    pub fn get_horizontal_strategy(&self) -> RepeatStrategy {
+        match self {
+            Self::Horizontal(strategy) => strategy.clone(),
+            Self::Bidirectional(strategy, _) => strategy.clone(),
+            _ => RepeatStrategy::Same,
+        }
+    }
+
+    pub fn get_vertical_strategy(&self) -> RepeatStrategy {
+        match self {
+            Self::Vertical(strategy) => strategy.clone(),
+            Self::Bidirectional(_, strategy) => strategy.clone(),
+            _ => RepeatStrategy::Same,
+        }
+    }
+}
+
 /// Layer initialization data
 #[derive(Debug, Deserialize, Resource)]
 #[serde(default)]
@@ -18,6 +93,9 @@ pub struct LayerData {
     /// Relative speed of layer to the camera movement.
     /// If the speed value is set to 1.0, the layer won't move in that direction.
     pub speed: LayerSpeed,
+
+    pub repeat: LayerRepeat,
+
     /// Path to layer texture file
     pub path: String,
     /// Size of a tile of the texture
@@ -42,6 +120,7 @@ impl Default for LayerData {
     fn default() -> Self {
         Self {
             speed: LayerSpeed::Horizontal(1.0),
+            repeat: LayerRepeat::Bidirectional(RepeatStrategy::Same, RepeatStrategy::Same),
             path: "".to_string(),
             tile_size: Vec2::ZERO,
             cols: 1,
@@ -60,12 +139,14 @@ impl Default for LayerData {
 pub struct LayerComponent {
     /// Relative speed of layer to the camera movement
     pub speed: Vec2,
+    ///
+    pub repeat: LayerRepeat,
     /// Number of rows (x) and columns (y) with the textures in the layer
     pub texture_count: Vec2,
     /// Number used to determine when textures are moved to opposite side of camera
     pub transition_factor: f32,
 
-    pub camera: Entity
+    pub camera: Entity,
 }
 
 /// Core component for layer texture

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -110,8 +110,6 @@ pub struct LayerData {
     pub z: f32,
     /// Default initial position of the Entity container
     pub position: Vec2,
-    /// Number used to determine when textures are moved to opposite side of camera
-    pub transition_factor: f32,
 
     pub color: Color,
 }
@@ -128,7 +126,6 @@ impl Default for LayerData {
             scale: 1.0,
             z: 0.0,
             position: Vec2::ZERO,
-            transition_factor: 1.2,
             color: Color::WHITE,
         }
     }
@@ -143,8 +140,6 @@ pub struct LayerComponent {
     pub repeat: LayerRepeat,
     /// Number of rows (x) and columns (y) with the textures in the layer
     pub texture_count: Vec2,
-    /// Number used to determine when textures are moved to opposite side of camera
-    pub transition_factor: f32,
 
     pub camera: Entity,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,34 +108,41 @@ fn update_layer_textures_system(
 
                 let texture_gtransform = texture_gtransform.compute_transform();
 
-                // Move right-most texture to left side of layer when camera is approaching left-most end
-                if camera_transform.translation.x - texture_gtransform.translation.x
-                    + ((layer_texture.width * texture_gtransform.scale.x) / 2.0)
-                    < -(view_size.x * layer.transition_factor)
-                {
-                    texture_transform.translation.x -= layer_texture.width * layer.texture_count.x;
-                // Move left-most texture to right side of layer when camera is approaching right-most end
-                } else if camera_transform.translation.x
-                    - texture_gtransform.translation.x
-                    - ((layer_texture.width * texture_gtransform.scale.x) / 2.0)
-                    > view_size.x * layer.transition_factor
-                {
-                    texture_transform.translation.x += layer_texture.width * layer.texture_count.x;
+                if layer.repeat.has_horizontal() {
+                    // Move right-most texture to left side of layer when camera is approaching left-most end
+                    if camera_transform.translation.x - texture_gtransform.translation.x
+                        + ((layer_texture.width * texture_gtransform.scale.x) / 2.0)
+                        < -(view_size.x * layer.transition_factor)
+                    {
+                        texture_transform.translation.x -=
+                            layer_texture.width * layer.texture_count.x;
+                    // Move left-most texture to right side of layer when camera is approaching right-most end
+                    } else if camera_transform.translation.x
+                        - texture_gtransform.translation.x
+                        - ((layer_texture.width * texture_gtransform.scale.x) / 2.0)
+                        > view_size.x * layer.transition_factor
+                    {
+                        texture_transform.translation.x +=
+                            layer_texture.width * layer.texture_count.x;
+                    }
                 }
-
-                // Move the top texture to the bottom of the layer when the camera is approaching the bottom
-                if camera_transform.translation.y - texture_gtransform.translation.y
-                    + ((layer_texture.height * texture_gtransform.scale.y) / 2.0)
-                    < -(view_size.y * layer.transition_factor)
-                {
-                    texture_transform.translation.y -= layer_texture.height * layer.texture_count.y;
-                // Move the bottom texture to the top of the layer when the camera is approaching the top
-                } else if camera_transform.translation.y
-                    - texture_gtransform.translation.y
-                    - ((layer_texture.height * texture_gtransform.scale.y) / 2.0)
-                    > view_size.y * layer.transition_factor
-                {
-                    texture_transform.translation.y += layer_texture.height * layer.texture_count.y;
+                if layer.repeat.has_vertical() {
+                    // Move the top texture to the bottom of the layer when the camera is approaching the bottom
+                    if camera_transform.translation.y - texture_gtransform.translation.y
+                        + ((layer_texture.height * texture_gtransform.scale.y) / 2.0)
+                        < -(view_size.y * layer.transition_factor)
+                    {
+                        texture_transform.translation.y -=
+                            layer_texture.height * layer.texture_count.y;
+                    // Move the bottom texture to the top of the layer when the camera is approaching the top
+                    } else if camera_transform.translation.y
+                        - texture_gtransform.translation.y
+                        - ((layer_texture.height * texture_gtransform.scale.y) / 2.0)
+                        > view_size.y * layer.transition_factor
+                    {
+                        texture_transform.translation.y +=
+                            layer_texture.height * layer.texture_count.y;
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,63 +85,72 @@ fn follow_camera_system(
 fn update_layer_textures_system(
     layer_query: Query<(&LayerComponent, &Children)>,
     mut texture_query: Query<
-        (&GlobalTransform, &mut Transform, &LayerTextureComponent),
+        (
+            &GlobalTransform,
+            &mut Transform,
+            &LayerTextureComponent,
+            &ComputedVisibility,
+        ),
         Without<ParallaxCameraComponent>,
     >,
     camera_query: Query<(Entity, &Transform, &Camera), With<ParallaxCameraComponent>>,
     window_query: Query<&Window, With<PrimaryWindow>>,
+    mut move_events: EventReader<ParallaxMoveEvent>,
 ) {
-    let primary_window = window_query.get_single().unwrap();
-    let window_size = Vec2::new(primary_window.width(), primary_window.height());
-    for (camera_entity, camera_transform, camera) in camera_query.iter() {
-        let view_size = match &camera.viewport {
-            Some(viewport) => viewport.physical_size.as_vec2(),
-            _ => window_size,
-        };
-        for (layer, children) in layer_query.iter() {
-            if layer.camera != camera_entity {
-                continue;
-            }
-            for &child in children.iter() {
-                let (texture_gtransform, mut texture_transform, layer_texture) =
-                    texture_query.get_mut(child).unwrap();
-
-                let texture_gtransform = texture_gtransform.compute_transform();
-
-                if layer.repeat.has_horizontal() {
-                    // Move right-most texture to left side of layer when camera is approaching left-most end
-                    if camera_transform.translation.x - texture_gtransform.translation.x
-                        + ((layer_texture.width * texture_gtransform.scale.x) / 2.0)
-                        < -(view_size.x * layer.transition_factor)
-                    {
-                        texture_transform.translation.x -=
-                            layer_texture.width * layer.texture_count.x;
-                    // Move left-most texture to right side of layer when camera is approaching right-most end
-                    } else if camera_transform.translation.x
-                        - texture_gtransform.translation.x
-                        - ((layer_texture.width * texture_gtransform.scale.x) / 2.0)
-                        > view_size.x * layer.transition_factor
-                    {
-                        texture_transform.translation.x +=
-                            layer_texture.width * layer.texture_count.x;
-                    }
+    for event in move_events.iter() {
+        if !event.has_movement() {
+            continue;
+        }
+        let primary_window = window_query.get_single().unwrap();
+        let window_size = Vec2::new(primary_window.width(), primary_window.height());
+        if let Ok((camera_entity, camera_transform, camera)) = camera_query.get(event.camera) {
+            let view_size = match &camera.viewport {
+                Some(viewport) => viewport.physical_size.as_vec2(),
+                _ => window_size,
+            };
+            for (layer, children) in layer_query.iter() {
+                if layer.camera != camera_entity {
+                    continue;
                 }
-                if layer.repeat.has_vertical() {
-                    // Move the top texture to the bottom of the layer when the camera is approaching the bottom
-                    if camera_transform.translation.y - texture_gtransform.translation.y
-                        + ((layer_texture.height * texture_gtransform.scale.y) / 2.0)
-                        < -(view_size.y * layer.transition_factor)
-                    {
-                        texture_transform.translation.y -=
-                            layer_texture.height * layer.texture_count.y;
-                    // Move the bottom texture to the top of the layer when the camera is approaching the top
-                    } else if camera_transform.translation.y
-                        - texture_gtransform.translation.y
-                        - ((layer_texture.height * texture_gtransform.scale.y) / 2.0)
-                        > view_size.y * layer.transition_factor
-                    {
-                        texture_transform.translation.y +=
-                            layer_texture.height * layer.texture_count.y;
+                for &child in children.iter() {
+                    let (
+                        texture_gtransform,
+                        mut texture_transform,
+                        layer_texture,
+                        computed_visibility,
+                    ) = texture_query.get_mut(child).unwrap();
+                    // Do not move visible textures
+                    if computed_visibility.is_visible() {
+                        continue;
+                    }
+                    let texture_gtransform = texture_gtransform.compute_transform();
+                    let texture_translation =
+                        camera_transform.translation - texture_gtransform.translation;
+                    if layer.repeat.has_horizontal() {
+                        let x_delta = layer_texture.width * layer.texture_count.x;
+                        let half_width = layer_texture.width * texture_gtransform.scale.x / 2.0;
+                        // Move not visible right texture to left side of layer when camera is moving to left
+                        if event.has_left_movement() && texture_translation.x + half_width < -view_size.x {
+                            texture_transform.translation.x -= x_delta;
+                        
+                        }
+                        // Move not visible left texture to right side of layer when camera is moving to right
+                        if event.has_right_movement() && texture_translation.x - half_width > view_size.x {
+                            texture_transform.translation.x += x_delta;
+                        }
+                    }
+                    if layer.repeat.has_vertical() {
+                        let y_delta = layer_texture.height * layer.texture_count.y;
+                        let half_height = layer_texture.height * texture_gtransform.scale.y / 2.0;
+                        // Move not visible top texture to the bottom of the layer when the camera is moving to the bottom
+                        if event.has_down_movement() && texture_translation.y + half_height < -view_size.y {
+                            texture_transform.translation.y -= y_delta;
+                        
+                        }
+                        // Move not visible bottom texture to the top of the layer when the camera is moving to the top
+                        if event.has_up_movement() && texture_translation.y - half_height > view_size.y {
+                            texture_transform.translation.y += y_delta;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
now it is possible to choose which axis to repeat, independently of the layer speed,
and how to repeat them with RepeatStrategy::( Same, Mirror )

Resolves https://github.com/Corrosive-Games/bevy-parallax/issues/26